### PR TITLE
Feature aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Option               | Type                 | Default                  | Descrip
 `containerClassName` | `string` \| `null`   | `'block-embed'`          | Class name for image container element.
 `serviceClassPrefix` | `string`             | `'block-embed-service-'` | Prefix for service name in CSS class.
 `outputPlayerSize`   | `boolean`            | `true`                   | Indicates if 'width' and 'height' attributes are written to output.
+`allowInstancePlayerSizeDefinition` | `boolean` | `false`              | Indicates whether individual player instances found within content may override the default size. Used by e.g.: `@[youtube](lJIrF4YjHfQ##400x300)`
 `allowFullScreen`    | `boolean`            | `true`                   | Indicates whether embed iframe should be allowed to enter full screen mode.
 `filterUrl`          | `function` \| `null` | `null`                   | A function that customizes url output. Signature: `function (url: string, serviceName: string, videoID: string, options: object): string`
                      |                      |                          |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Option               | Type                 | Default                  | Descrip
 `containerClassName` | `string` \| `null`   | `'block-embed'`          | Class name for image container element.
 `serviceClassPrefix` | `string`             | `'block-embed-service-'` | Prefix for service name in CSS class.
 `outputPlayerSize`   | `boolean`            | `true`                   | Indicates if 'width' and 'height' attributes are written to output.
+`outputPlayerAspectRatio`   | `boolean`            | `false`                   | Indicates if a second container element with a `padding-top` percentage `style` attribute is written to output. This can be used for a dynamically-sized block whilst adhering to an aspect ratio. You must use `css` to absolutely position the iframe within this element
 `allowInstancePlayerSizeDefinition` | `boolean` | `false`              | Indicates whether individual player instances found within content may override the default size. Used by e.g.: `@[youtube](lJIrF4YjHfQ##400x300)`
 `allowFullScreen`    | `boolean`            | `true`                   | Indicates whether embed iframe should be allowed to enter full screen mode.
 `filterUrl`          | `function` \| `null` | `null`                   | A function that customizes url output. Signature: `function (url: string, serviceName: string, videoID: string, options: object): string`
@@ -74,7 +75,7 @@ Option               | Type                 | Default                  | Descrip
 `services.vine`      | `function`           | `VineService`            | Implementation of the 'vine' embed service. Can be overridden by a custom implementation.
 `services.prezi`     | `function`           | `PreziService`           | Implementation of the 'prezi' embed service. Can be overridden by a custom implementation.
                      |                      |                          |
-`{service-name}`     | `object`             | -                        | Options can be supplied to embed services. 
+`{service-name}`     | `object`             | -                        | Options can be supplied to embed services.
                      |                      |                          |
 `youtube.width`      | `number`             | `640`                    | Width of YouTube embed.
 `youtube.height`     | `number`             | `390`                    | Height of YouTube embed.
@@ -197,7 +198,7 @@ Alternately, you could use the url, or even the whole embed tag instead of just 
 @[prezi](1kkxdtlp4241)
 ```
 
-is interpreted as 
+is interpreted as
 
 ```html
 <div class="block-embed block-embed-service-prezi">

--- a/lib/PluginEnvironment.js
+++ b/lib/PluginEnvironment.js
@@ -41,6 +41,7 @@ class PluginEnvironment {
       containerClassName: "block-embed",
       serviceClassPrefix: "block-embed-service-",
       outputPlayerSize: true,
+      allowInstancePlayerSizeDefinition: false,
       allowFullScreen: true,
       filterUrl: null
     };

--- a/lib/PluginEnvironment.js
+++ b/lib/PluginEnvironment.js
@@ -41,6 +41,7 @@ class PluginEnvironment {
       containerClassName: "block-embed",
       serviceClassPrefix: "block-embed-service-",
       outputPlayerSize: true,
+      outputPlayerAspectRatio: false,
       allowInstancePlayerSizeDefinition: false,
       allowFullScreen: true,
       filterUrl: null

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -9,8 +9,9 @@ function renderer(tokens, idx, options, _env) {
 
   let service = videoToken.info.service;
   let videoID = videoToken.info.videoID;
+  let videoDimensionsInfo = videoToken.info.videoDimensionsInfo;
 
-  return service.getEmbedCode(videoID);
+  return service.getEmbedCode(videoID, videoDimensionsInfo);
 }
 
 

--- a/lib/services/VideoServiceBase.js
+++ b/lib/services/VideoServiceBase.js
@@ -37,7 +37,7 @@ class VideoServiceBase {
     return filterUrlDelegate(videoUrl, this.name, videoID, this.env.options);
   }
 
-  getEmbedCode(videoID) {
+  getEmbedCode(videoID, videoDimensionsInfo) {
     let containerClassNames = [];
     if (this.env.options.containerClassName) {
       containerClassNames.push(this.env.options.containerClassName);
@@ -51,12 +51,16 @@ class VideoServiceBase {
     iframeAttributeList.push([ "src", this.getFilteredVideoUrl(videoID) ]);
     iframeAttributeList.push([ "frameborder", 0 ]);
 
+    //collect default player dimensions from config and allow override from player instance, if available
+    let playerWidth = videoDimensionsInfo.Width || this.options.width;
+    let playerHeight = videoDimensionsInfo.Height || this.options.height;
+    //ouptut width and height if we are configured to do so (and values are valid)
     if (this.env.options.outputPlayerSize === true) {
-      if (this.options.width !== undefined && this.options.width !== null) {
-        iframeAttributeList.push([ "width", this.options.width ]);
+      if (playerWidth !== undefined && playerWidth !== null) {
+        iframeAttributeList.push([ "width", playerWidth ]);
       }
-      if (this.options.height !== undefined && this.options.height !== null) {
-        iframeAttributeList.push([ "height", this.options.height ]);
+      if (playerHeight !== undefined && playerHeight !== null) {
+        iframeAttributeList.push([ "height", playerHeight ]);
       }
     }
 

--- a/lib/services/VideoServiceBase.js
+++ b/lib/services/VideoServiceBase.js
@@ -51,10 +51,10 @@ class VideoServiceBase {
     iframeAttributeList.push([ "src", this.getFilteredVideoUrl(videoID) ]);
     iframeAttributeList.push([ "frameborder", 0 ]);
 
-    //collect default player dimensions from config and allow override from player instance, if available
+    // collect default player dimensions from config and allow override from player instance, if available
     let playerWidth = videoDimensionsInfo.Width || this.options.width;
     let playerHeight = videoDimensionsInfo.Height || this.options.height;
-    //ouptut width and height if we are configured to do so (and values are valid)
+    // ouptut width and height if we are configured to do so (and values are valid)
     if (this.env.options.outputPlayerSize === true) {
       if (playerWidth !== undefined && playerWidth !== null) {
         iframeAttributeList.push([ "width", playerWidth ]);

--- a/lib/services/VideoServiceBase.js
+++ b/lib/services/VideoServiceBase.js
@@ -38,11 +38,11 @@ class VideoServiceBase {
   }
 
   getEmbedCode(videoID, videoDimensionsInfo) {
-    let containerClassNames = [];
+    let containerClassNames = [ ];
     if (this.env.options.containerClassName) {
       containerClassNames.push(this.env.options.containerClassName);
     }
-    //config for 'viewport' element
+    // config for 'viewport' element
     const mediaViewportClassName = `${this.env.options.containerClassName}__viewport`;
     let mediaViewportExists = false;
     const mediaViewportAttributeList = [];
@@ -66,24 +66,22 @@ class VideoServiceBase {
       if (playerHeight !== undefined && playerHeight !== null) {
         iframeAttributeList.push([ "height", playerHeight ]);
       }
-    }
-    //output aspect ratio on media viewport element if we are configured to do so
-    else if (this.env.options.outputPlayerAspectRatio === true) {
-      //get explicit aspect ratio
+    } else if (this.env.options.outputPlayerAspectRatio === true) {
+      // output aspect ratio on media viewport element if we are configured to do so
+      // get explicit aspect ratio
       let aspectRatio = videoDimensionsInfo.AspectRatio;
       if (!aspectRatio && playerWidth && playerHeight) {
-        //calculate aspect ratio from dimensions
+        // calculate aspect ratio from dimensions
         aspectRatio = (playerHeight / playerWidth) * 100;
       }
-      //only proceed if we have aspect ratio data
+      // only proceed if we have aspect ratio data
       if (aspectRatio) {
-        //need extra container
+        // need extra container
         mediaViewportExists = true;
-        //aspect ratio is achieved with padding and must go hand-in-hand with other styles (e.g. absolute positioning)
-        mediaViewportAttributeList.push(["style", `padding-top: ${aspectRatio}%`]);
+        // aspect ratio is achieved with padding and must go hand-in-hand with other styles (e.g. absolute positioning)
+        mediaViewportAttributeList.push([ "style", `padding-top: ${aspectRatio}%` ]);
       }
     }
-
 
     if (this.env.options.allowFullScreen === true) {
       iframeAttributeList.push([ "webkitallowfullscreen" ]);
@@ -108,9 +106,9 @@ class VideoServiceBase {
       .join(" ");
 
     return `<div class="${containerClassNames.join(" ")}">`
-            + (mediaViewportExists ? `<div class="${mediaViewportClassName}" ${mediaViewportAttributes}>` : '')
+            + (mediaViewportExists ? `<div class="${mediaViewportClassName}" ${mediaViewportAttributes}>` : "")
             + `<iframe ${iframeAttributes}></iframe>`
-           + (mediaViewportExists ? `</div>` : '')
+           + (mediaViewportExists ? `</div>` : "")
          + `</div>\n`;
   }
 

--- a/lib/services/VideoServiceBase.js
+++ b/lib/services/VideoServiceBase.js
@@ -42,6 +42,10 @@ class VideoServiceBase {
     if (this.env.options.containerClassName) {
       containerClassNames.push(this.env.options.containerClassName);
     }
+    //config for 'viewport' element
+    const mediaViewportClassName = `${this.env.options.containerClassName}__viewport`;
+    let mediaViewportExists = false;
+    const mediaViewportAttributeList = [];
 
     let escapedServiceName = this.env.md.utils.escapeHtml(this.name);
     containerClassNames.push(this.env.options.serviceClassPrefix + escapedServiceName);
@@ -55,7 +59,7 @@ class VideoServiceBase {
     let playerWidth = videoDimensionsInfo.Width || this.options.width;
     let playerHeight = videoDimensionsInfo.Height || this.options.height;
     //ouptut width and height if we are configured to do so (and values are valid)
-    if (this.env.options.outputPlayerSize === true) {
+    if (this.env.options.outputPlayerSize === true && (playerWidth || playerHeight)) {
       if (playerWidth !== undefined && playerWidth !== null) {
         iframeAttributeList.push([ "width", playerWidth ]);
       }
@@ -63,6 +67,23 @@ class VideoServiceBase {
         iframeAttributeList.push([ "height", playerHeight ]);
       }
     }
+    //output aspect ratio on media viewport element if we are configured to do so
+    else if (this.env.options.outputPlayerAspectRatio === true) {
+      //get explicit aspect ratio
+      let aspectRatio = videoDimensionsInfo.AspectRatio;
+      if (!aspectRatio && playerWidth && playerHeight) {
+        //calculate aspect ratio from dimensions
+        aspectRatio = (playerHeight / playerWidth) * 100;
+      }
+      //only proceed if we have aspect ratio data
+      if (aspectRatio) {
+        //need extra container
+        mediaViewportExists = true;
+        //aspect ratio is achieved with padding and must go hand-in-hand with other styles (e.g. absolute positioning)
+        mediaViewportAttributeList.push(["style", `padding-top: ${aspectRatio}%`]);
+      }
+    }
+
 
     if (this.env.options.allowFullScreen === true) {
       iframeAttributeList.push([ "webkitallowfullscreen" ]);
@@ -78,8 +99,18 @@ class VideoServiceBase {
       )
       .join(" ");
 
+    const mediaViewportAttributes = mediaViewportAttributeList
+      .map(pair =>
+        pair[1] !== undefined
+            ? `${pair[0]}="${pair[1]}"`
+            : pair[0]
+      )
+      .join(" ");
+
     return `<div class="${containerClassNames.join(" ")}">`
-           + `<iframe ${iframeAttributes}></iframe>`
+            + (mediaViewportExists ? `<div class="${mediaViewportClassName}" ${mediaViewportAttributes}>` : '')
+            + `<iframe ${iframeAttributes}></iframe>`
+           + (mediaViewportExists ? `</div>` : '')
          + `</div>\n`;
   }
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -107,6 +107,11 @@ function tokenizer(state, startLine, endLine, silent) {
           videoDimensionsInfo.Width = videoDimensionsComponents[0];
           videoDimensionsInfo.Height = videoDimensionsComponents[1];
         }
+        else if (videoDimensionsComponents.length === 1) {
+          //should be aspect ratio (assume int)
+          videoDimensionsInfo.AspectRatio = videoDimensionsComponents[0];
+        }
+        //future: detect if more than 2 components for third (currently unused) option...
       }
     }
     token.markup = state.src.slice(startPos, pointer.pos);

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -106,12 +106,11 @@ function tokenizer(state, startLine, endLine, silent) {
           // should be width and height
           videoDimensionsInfo.Width = videoDimensionsComponents[0];
           videoDimensionsInfo.Height = videoDimensionsComponents[1];
-        }
-        else if (videoDimensionsComponents.length === 1) {
-          //should be aspect ratio (assume int)
+        } else if (videoDimensionsComponents.length === 1) {
+          // should be aspect ratio (assume int)
           videoDimensionsInfo.AspectRatio = videoDimensionsComponents[0];
         }
-        //future: detect if more than 2 components for third (currently unused) option...
+        // future: detect if more than 2 components for third (currently unused) option...
       }
     }
     token.markup = state.src.slice(startPos, pointer.pos);

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -90,13 +90,33 @@ function tokenizer(state, startLine, endLine, silent) {
 
   if (!silent) {
     let token = state.push("video", "div", 0);
+    //object for storing and passing what we know about the player instance dimensions
+    let videoDimensionsInfo = {};
+    //configuration option allows us to parse player size for individual player instances
+    if (this.options.allowInstancePlayerSizeDefinition === true) {
+      const videoReferenceComponents = videoReference.split('##');
+      if (videoReferenceComponents.length > 1) {
+        //first component is url / ID
+        videoReference = videoReferenceComponents[0];
+        //second component is size information
+        //either a width/height or a single aspect ratio value (as height percentage of width)
+        //find if is a string split by 'x' i.e. XXXxYYY
+        const videoDimensionsComponents = videoReferenceComponents[1].split('x');
+        if (videoDimensionsComponents.length === 2) {
+          //should be width and height
+          videoDimensionsInfo.Width = videoDimensionsComponents[0];
+          videoDimensionsInfo.Height = videoDimensionsComponents[1];
+        }
+      }
+    }
     token.markup = state.src.slice(startPos, pointer.pos);
     token.block = true;
     token.info = {
       serviceName: serviceName,
       service: service,
       videoReference: videoReference,
-      videoID: service.extractVideoID(videoReference)
+      videoID: service.extractVideoID(videoReference),
+      videoDimensionsInfo: videoDimensionsInfo
     };
     token.map = [ startLine, pointer.line + 1 ];
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -90,20 +90,20 @@ function tokenizer(state, startLine, endLine, silent) {
 
   if (!silent) {
     let token = state.push("video", "div", 0);
-    //object for storing and passing what we know about the player instance dimensions
+    // object for storing and passing what we know about the player instance dimensions
     let videoDimensionsInfo = {};
-    //configuration option allows us to parse player size for individual player instances
+    // configuration option allows us to parse player size for individual player instances
     if (this.options.allowInstancePlayerSizeDefinition === true) {
-      const videoReferenceComponents = videoReference.split('##');
+      const videoReferenceComponents = videoReference.split("##");
       if (videoReferenceComponents.length > 1) {
-        //first component is url / ID
+        // first component is url / ID
         videoReference = videoReferenceComponents[0];
-        //second component is size information
-        //either a width/height or a single aspect ratio value (as height percentage of width)
-        //find if is a string split by 'x' i.e. XXXxYYY
-        const videoDimensionsComponents = videoReferenceComponents[1].split('x');
+        // second component is size information
+        // either a width/height or a single aspect ratio value (as height percentage of width)
+        // find if is a string split by 'x' i.e. XXXxYYY
+        const videoDimensionsComponents = videoReferenceComponents[1].split("x");
         if (videoDimensionsComponents.length === 2) {
-          //should be width and height
+          // should be width and height
           videoDimensionsInfo.Width = videoDimensionsComponents[0];
           videoDimensionsInfo.Height = videoDimensionsComponents[1];
         }

--- a/test/fixtures/aspect-ratio.txt
+++ b/test/fixtures/aspect-ratio.txt
@@ -1,0 +1,37 @@
+Coverage. Instance size attributes with aspect ratio
+
+.
+@[vimeo](19706846##123x45)
+.
+<div class="block-embed block-embed-service-vimeo"><div class="block-embed__viewport" style="padding-top: 36.58536585365854%"><iframe type="text/html" src="//player.vimeo.com/video/19706846" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></div>
+.
+
+.
+@[example](x##5x6)
+.
+<div class="block-embed block-embed-service-example"><div class="block-embed__viewport" style="padding-top: 120%"><iframe type="text/html" src="https://example.com/embed/x/42" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></div>
+.
+
+.
+@[vimeo](19706846##56.25)
+.
+<div class="block-embed block-embed-service-vimeo"><div class="block-embed__viewport" style="padding-top: 56.25%"><iframe type="text/html" src="//player.vimeo.com/video/19706846" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></div>
+.
+
+.
+@[example](x##120)
+.
+<div class="block-embed block-embed-service-example"><div class="block-embed__viewport" style="padding-top: 120%"><iframe type="text/html" src="https://example.com/embed/x/42" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></div>
+.
+
+.
+@[vimeo](19706846)
+.
+<div class="block-embed block-embed-service-vimeo"><div class="block-embed__viewport" style="padding-top: 56.2%"><iframe type="text/html" src="//player.vimeo.com/video/19706846" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></div>
+.
+
+.
+@[example](x)
+.
+<div class="block-embed block-embed-service-example"><iframe type="text/html" src="https://example.com/embed/x/42" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
+.

--- a/test/fixtures/instance-size-attributes.txt
+++ b/test/fixtures/instance-size-attributes.txt
@@ -1,0 +1,13 @@
+Coverage. Instance size attributes
+
+.
+@[vimeo](19706846##123x45)
+.
+<div class="block-embed block-embed-service-vimeo"><iframe type="text/html" src="//player.vimeo.com/video/19706846" frameborder="0" width="123" height="45" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
+.
+
+.
+@[example](x##5x6)
+.
+<div class="block-embed block-embed-service-example"><iframe type="text/html" src="https://example.com/embed/x/42" frameborder="0" width="5" height="6" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,13 @@ describe("markdown-it-video", function () {
     });
   });
 
+  describe("with instance size attributes", function () {
+    testFixtureWithExampleService("instance-size-attributes", {
+      allowFullScreen: true,
+      allowInstancePlayerSizeDefinition: true
+    });
+  });
+
   describe("providing custom services", function () {
     testFixture("custom-service", {
       services: {

--- a/test/test.js
+++ b/test/test.js
@@ -77,7 +77,7 @@ describe("markdown-it-video", function () {
       allowFullScreen: true,
       allowInstancePlayerSizeDefinition: true,
       outputPlayerSize: false,
-      outputPlayerAspectRatio: true,
+      outputPlayerAspectRatio: true
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,15 @@ describe("markdown-it-video", function () {
     });
   });
 
+  describe("with aspect ratio attributes", function () {
+    testFixtureWithExampleService("aspect-ratio", {
+      allowFullScreen: true,
+      allowInstancePlayerSizeDefinition: true,
+      outputPlayerSize: false,
+      outputPlayerAspectRatio: true,
+    });
+  });
+
   describe("providing custom services", function () {
     testFixture("custom-service", {
       services: {


### PR DESCRIPTION
A problem with the `outputPlayerSize` option is that it is not good for fluid widths, i.e. responsive design where you may use `width: 100%; max-width: 800px` on a media element, for example.

In order to have a fluid-width media element, you need the height to grow proportionally to the width and the aspect ratio of the media element. This happens by default for images, but not for videos. Instead, it is common to use the padding-top percentage trick. (when a percentage is used for padding-top or padding-bottom, it is actually a percentage of it's container width).

This adds an option `outputPlayerAspectRatio` which outputs an additional container element, required for this common technique, and adds the `style="padding-top: XX.XX%` attribute to this element.

Users must also add `position: relative;` to this element, keep it at the default `width: 100%`, and position the media iframe `position: absolute; top: 0; left: 0; width: 100%; height: 100%`. Then whatever width or max-width the outer container is set at, the height of the video will grow and shrink accordingly.
- [x] code
- [x] test
- [x] documentation
- [x] linter and spec passes

_note: rather inappropriately, this branch is based on the branch from #3 and so should not be merged until that PR is._
